### PR TITLE
get_iface_ip_addr returning all ip adresses.

### DIFF
--- a/wishful_module_net_linux/linux_net_module.py
+++ b/wishful_module_net_linux/linux_net_module.py
@@ -47,9 +47,14 @@ class NetworkModule(wishful_module.AgentModule):
 
     @wishful_module.bind_function(upis.net.get_iface_ip_addr)
     def get_iface_ip_addr(self, iface):
-
-        ip = ni.ifaddresses(iface)[2][0]['addr']
-        return ip
+        """Interfaces may have multiple addresses, return a list with all addresses
+        """
+        #ip = ni.ifaddresses(iface)[2][0]['addr'] #this will return only the first ip address
+        #return ip
+        
+        #this returns a list with all ip addresses
+        ipList = [inetaddr['addr'] for inetaddr in ni.ifaddresses(iface)[ni.AF_INET]] 
+        return ipList
 
 
     @wishful_module.bind_function(upis.net.change_routing)


### PR DESCRIPTION
`get_iface_ip_addr` returning all ip adresses.

might need an update on net upi documentation

```
def get_iface_ip_addr(iface):
    '''Returns a list with all IP addresses of a given interface.
    '''
    return
```

or a new upi (get_iface_ip_addresses?)

from https://pypi.python.org/pypi/netifaces

> The reason is that it’s possible for an interface to have more than one address, even within the same family. I’ll say that again: you can have more than one address of the same type associated with each interface.
> 
> Asking for “the” address of a particular interface doesn’t make sense.
